### PR TITLE
Fix cgroup-limit test on Ubuntu 24.10 Oracular Oriole

### DIFF
--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -48,11 +48,11 @@ if [ "$UID" != "0" ]; then
   fi
 fi
 
-mapfile -t DOTNET_LIMITS < <($SYSTEMD_RUN  -q --scope -p CPUQuota=100% -p MemoryLimit=100M bin/Release/net*/cgroup-limit)
+mapfile -t DOTNET_LIMITS < <($SYSTEMD_RUN  -q --scope -p CPUQuota=100% -p MemoryLimit=200M bin/Release/net*/cgroup-limit)
 
 if [ "${DOTNET_LIMITS[0]}" == "Limits:" ] &&      # Application ran.
    [ "${DOTNET_LIMITS[1]}" == "1" ] &&            # Available processors is 1.
-   [ "${DOTNET_LIMITS[2]}" -lt 100000000 ]; then  # Available memory less is than 100M.
+   [ "${DOTNET_LIMITS[2]}" -lt 200000000 ]; then  # Available memory less is than 200M.
   echo ".NET Runtime uses cgroup limits PASS"
   exit 0
 fi


### PR DESCRIPTION
I noticed that `dotnet8` autopkgtests on Oracular have been failing consistently on all architectures, always on the test cgroup-limit (see [example](https://autopkgtest.ubuntu.com/results/autopkgtest-oracular/oracular/amd64/d/dotnet8/20240814_154658_c349e@/log.gz)). It was fairly easy to reproduce the behavior on an Oracular VM:

```
# dotnet /home/ubuntu/dotnet-test-runner/Turkey/bin/Debug/net6.0/Turkey.dll --test-name cgroup-limit
Testing everything under /home/ubuntu/dotnet-regular-tests
Current platform is: linux, linux-x64, ubuntu, ubuntu-x64, ubuntu24.10, ubuntu.24.10, ubuntu.24.10-x64
Tests matching these traits will be skipped: arch=x64, os=linux, os=ubuntu, os=ubuntu.24.10, rid=linux, rid=linux-x64, rid=ubuntu, rid=ubuntu-x64, rid=ubuntu.24.10, rid=ubuntu.24.10-x64, rid=ubuntu24.10, runtime=coreclr, version=8, version=8.0.
Running tests:
cgroup-limit                                                [FAIL]      (2s)

The following tests failed: 
cgroup-limit                  (2s)

Total: 1 Passed: 0 Failed: 1
```

This test executes the script `cgroup-limit/test.sh`, which launches a `systemd.scope` unit that executes a .NET program within a memory-limited cgroup. So, running the `systemd-run` command directly makes the error a little more obvious:

```
# systemd-run --scope -p CPUQuota=100% -p MemoryLimit=100M bin/Release/net8.0/cgroup-limit                       
Running as unit: run-r9a06bd833e06411e9f979ab12692be60.scope; invocation ID: 55874dd982974640b0fe1e4dfd43eebb                                                                
Killed
```
Examining the unit status a little more closely, shows that it was killed by the OOM Killer:

```
# systemctl status run-r9a06bd833e06411e9f979ab12692be60.scope                                                   
× run-r9a06bd833e06411e9f979ab12692be60.scope - /home/ubuntu/dotnet-regular-tests/cgroup-limit/bin/Release/net8.0/cgroup-limit                                               
     Loaded: loaded (/run/systemd/transient/run-r9a06bd833e06411e9f979ab12692be60.scope; transient)                                                                          
  Transient: yes                                                                                                                                                             
     Active: failed (Result: oom-kill) since Fri 2024-08-16 10:22:28 -03; 46s ago                                                                                            
   Duration: 31ms                                                                                                                                                            
 Invocation: 55874dd982974640b0fe1e4dfd43eebb                                                                                                                                
                                                                                                                                                                             
Aug 16 10:22:28 oracular systemd[1]: Started run-r9a06bd833e06411e9f979ab12692be60.scope - /home/ubuntu/dotnet-regular-tests/cgroup-limit/bin/Release/net8.0/cgroup-limit.   
Aug 16 10:22:28 oracular systemd[1]: run-r9a06bd833e06411e9f979ab12692be60.scope: A process of this unit has been killed by the OOM killer.                                  
Aug 16 10:22:28 oracular systemd[1]: run-r9a06bd833e06411e9f979ab12692be60.scope: Failed with result 'oom-kill'.
```

Interestingly enough, running the same command on a Noble VM does execute to the end succesfully:

```
# systemd-run --scope -p CPUQuota=100% -p MemoryLimit=100M bin/Release/net8.0/cgroup-limit
Running as unit: run-rb48982bf5e4f4deebb40efde4e9a4ff0.scope; invocation ID: cda5ac4363e7436f97e266376a3db079
Limits:
1
78643200
```

It is not 100% clear to me why this is the case, maybe something changed in the OOM Killer in between kernels, but bumping the memory limit property on the systemd-run command should fix the problem for Oracular without negatively impacting the test's accuracy:

```
# systemd-run --scope -p CPUQuota=100% -p MemoryLimit=200M cgroup-limit/bin/Release/net8.0/cgroup-limit
Running as unit: run-raafabb5488044c1ca1ef20425759bc72.scope; invocation ID: f73de50077d34ad389087d65e6ed0bf0
Limits:
1
157286400
```
```
# dotnet /home/ubuntu/dotnet-test-runner/Turkey/bin/Debug/net6.0/Turkey.dll --test-name cgroup-limit
Testing everything under /home/ubuntu/dotnet-regular-tests
Current platform is: linux, linux-x64, ubuntu, ubuntu-x64, ubuntu24.10, ubuntu.24.10, ubuntu.24.10-x64
Tests matching these traits will be skipped: arch=x64, os=linux, os=ubuntu, os=ubuntu.24.10, rid=linux, rid=linux-x64, rid=ubuntu, rid=ubuntu-x64, rid=ubuntu.24.10, rid=ubuntu.24.10-x64, rid=ubuntu24.10, runtime=coreclr, version=8, version=8.0.
Running tests:
cgroup-limit                                                [PASS]      (4s)

The following tests failed: 

Total: 1 Passed: 1 Failed: 0
```